### PR TITLE
Add version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   list        Lists all attestations
+  version     Prints the fatt version
 
 Flags:
   -p, --file-path string   the filepath to find attestation purls (defaults to current working dir)

--- a/cmd/fatt/cli/cli.go
+++ b/cmd/fatt/cli/cli.go
@@ -22,6 +22,7 @@ func New() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewListCommand())
+	cmd.AddCommand(Version())
 
 	ro.AddFlags(cmd)
 

--- a/cmd/fatt/cli/cli.go
+++ b/cmd/fatt/cli/cli.go
@@ -22,7 +22,7 @@ func New() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewListCommand())
-	cmd.AddCommand(Version())
+	cmd.AddCommand(NewVersionCommand())
 
 	ro.AddFlags(cmd)
 

--- a/cmd/fatt/cli/options/version.go
+++ b/cmd/fatt/cli/options/version.go
@@ -1,0 +1,17 @@
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// VersionOptions commandline options for the version command
+type VersionOptions struct {
+	OutputFormat string
+}
+
+var _ CommandFlagger = (*VersionOptions)(nil)
+
+// AddFlags implements CommandFlagger to add the RootOptions as flags to the given command
+func (o *VersionOptions) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&o.OutputFormat, "output-format", "o", "", "output format for the version command, valid option is: json")
+}

--- a/cmd/fatt/cli/version.go
+++ b/cmd/fatt/cli/version.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func Version() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: fmt.Sprintf("Prints the %s version", cliName),
+		Long:  fmt.Sprintf("Prints the %s version", cliName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := VersionInfo()
+			res := v.String()
+			fmt.Fprintln(cmd.OutOrStdout(), res)
+			return nil
+		},
+	}
+	return cmd
+}
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags (e.g. via Makefile).
+var (
+	// Output of "git describe". The prerequisite is that the branch should be
+	// tagged using the correct versioning strategy.
+	GitVersion string = "devel"
+	// SHA1 from git, output of $(git rev-parse HEAD)
+	gitCommit = "unknown"
+	// State of git tree, either "clean" or "dirty"
+	gitTreeState = "unknown"
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate = "unknown"
+)
+
+// Info holds the version information of the binary
+type Info struct {
+	GitVersion   string `json:"git_version,omitempty"`
+	GitCommit    string `json:"git_commit,omitempty"`
+	GitTreeState string `json:"git_tree_state,omitempty"`
+	BuildDate    string `json:"build_date,omitempty"`
+	GoVersion    string `json:"go_version,omitempty"`
+	Compiler     string `json:"compiler,omitempty"`
+	Platform     string `json:"platform,omitempty"`
+}
+
+// VersionInfo creates an instance of the Info structure
+func VersionInfo() Info {
+	return Info{
+		GitVersion:   GitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// String returns the string representation of the version info
+func (i *Info) String() string {
+	b := strings.Builder{}
+	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
+	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
+	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
+	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
+	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+
+	w.Flush()
+	return b.String()
+}

--- a/cmd/fatt/cli/version_test.go
+++ b/cmd/fatt/cli/version_test.go
@@ -1,0 +1,70 @@
+package cli_test
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/philips-labs/fatt/cmd/fatt/cli"
+)
+
+func TestVersionCliText(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := fmt.Sprintf(
+		`GitVersion:    devel
+GitCommit:     unknown
+GitTreeState:  unknown
+BuildDate:     unknown
+GoVersion:     %s
+Compiler:      %s
+Platform:      %s/%s
+`, runtime.Version(), runtime.Compiler, runtime.GOOS, runtime.GOARCH)
+
+	output, err := executeCommand(cli.NewVersionCommand())
+	assert.NoError(err)
+	assert.Equal(expected, output)
+}
+
+func TestVersionCliJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := fmt.Sprintf(`{
+  "git_version": "devel",
+  "git_commit": "unknown",
+  "git_tree_state": "unknown",
+  "build_date": "unknown",
+  "go_version": "%s",
+  "compiler": "%s",
+  "platform": "%s/%s"
+}
+`, runtime.Version(), runtime.Compiler, runtime.GOOS, runtime.GOARCH)
+	a := []string{"-o", "json"}
+	output, err := executeCommand(cli.NewVersionCommand(), a...)
+	assert.NoError(err)
+	assert.Equal(expected, output)
+
+	a = []string{"--output-format", "json"}
+	output, err = executeCommand(cli.NewVersionCommand(), a...)
+	assert.NoError(err)
+	assert.Equal(expected, output)
+}
+
+func executeCommand(cmd *cobra.Command, args ...string) (output string, err error) {
+	_, output, err = executeCommandC(cmd, args...)
+	return output, err
+}
+
+func executeCommandC(cmd *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	cmd.SetOutput(buf)
+	cmd.SetArgs(args)
+
+	c, err = cmd.ExecuteC()
+
+	return c, buf.String(), err
+}


### PR DESCRIPTION
Add the version command with an optional command flag to customize the output-format to json. In the future, other output-formats could be added easily.
Output-formats name was chosen to align with the rest of the CLI flags.

Closes #8 

Signed-off-by: Brend Smits <brend.smits@philips.com>