### PR TITLE
Add tag prefix that allows you to store attestations in a single registry

### DIFF
--- a/cmd/fatt/cli/options/publish.go
+++ b/cmd/fatt/cli/options/publish.go
@@ -10,6 +10,7 @@ type PublishOptions struct {
 	Version      string
 	Repository   string
 	Attestations []string
+	TagPrefix    string
 }
 
 // NewPublishOptions initializes the ListOptions object
@@ -23,5 +24,6 @@ var _ CommandFlagger = (*PublishOptions)(nil)
 func (o *PublishOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&o.Version, "version", "", "", "the version to publish the attestations for.")
 	cmd.PersistentFlags().StringVarP(&o.Repository, "repository", "", "", "the oci repository to publish the attestation in.")
+	cmd.PersistentFlags().StringVarP(&o.TagPrefix, "tag-prefix", "", "", "the tag prefix that is used to store various attestations in a single registry")
 	o.OCIOptions.AddFlags(cmd)
 }

--- a/cmd/fatt/cli/publish.go
+++ b/cmd/fatt/cli/publish.go
@@ -77,7 +77,7 @@ func NewPublishCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				r, err := attestation.Publish(ctx, po.Repository, po.Version, att)
+				r, err := attestation.Publish(ctx, po.Repository, po.TagPrefix, po.Version, att)
 				if err != nil {
 					return err
 				}
@@ -87,7 +87,7 @@ func NewPublishCommand() *cobra.Command {
 
 			fmt.Fprintln(os.Stderr)
 			fmt.Fprintln(os.Stderr, "Generating attestations.txt based on uploaded attestations…")
-			_, err := attestation.Publish(ctx, po.Repository, po.Version, purls)
+			_, err := attestation.Publish(ctx, po.Repository, po.TagPrefix, po.Version, purls)
 			if err != nil {
 				return err
 			}

--- a/installer-action/action.yaml
+++ b/installer-action/action.yaml
@@ -22,7 +22,9 @@ runs:
         VERSION: ${{ inputs.fatt-release }}
         INSTALL_PATH: ${{ inputs.install-dir }}
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
+      run: |
+        echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
+        echo "binary installed at $(command -v fatt)"
       shell: bash
     - if: ${{ runner.os == 'Windows' }}
       run:  echo "${{ inputs.install-dir }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/pkg/attestation/publish.go
+++ b/pkg/attestation/publish.go
@@ -78,11 +78,11 @@ func ParseFileRef(fileRef string) (File, error) {
 // Publish publishes the attestations to an oci repository
 func Publish(ctx context.Context, repository, tagPrefix string, version string, att cremote.File) (*PublishResult, error) {
 	if strings.TrimSpace(repository) == "" {
-		return nil, errors.New("repository parameter is required")
+		return nil, errors.New("repository is required")
 	}
 
 	if att == nil {
-		return nil, errors.New("attestation file parameter is required")
+		return nil, errors.New("attestation file is required")
 	}
 
 	t, err := getType(att.String())

--- a/pkg/attestation/publish.go
+++ b/pkg/attestation/publish.go
@@ -76,13 +76,13 @@ func ParseFileRef(fileRef string) (File, error) {
 }
 
 // Publish publishes the attestations to an oci repository
-func Publish(ctx context.Context, repository, version string, att cremote.File) (*PublishResult, error) {
+func Publish(ctx context.Context, repository, tagPrefix string, version string, att cremote.File) (*PublishResult, error) {
 	t, err := getType(att.String())
 	if err != nil {
 		return nil, err
 	}
 
-	ociRef := fmt.Sprintf("%s:%s.%s", repository, version, t)
+	ociRef := fmt.Sprintf("%s:%s-%s.%s", repository, tagPrefix, version, t)
 
 	ref, err := name.ParseReference(ociRef)
 	if err != nil {

--- a/pkg/attestation/publish_test.go
+++ b/pkg/attestation/publish_test.go
@@ -42,7 +42,6 @@ func (f mockFile) String() string {
 var _ cremote.File = mockFile{}
 
 func TestBuildOciRef(t *testing.T) {
-
 	testCases := []struct {
 		name           string
 		repo           string

--- a/pkg/attestation/publish_test.go
+++ b/pkg/attestation/publish_test.go
@@ -1,0 +1,166 @@
+package attestation
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockFile struct {
+	scheme string
+	path   string
+}
+
+// Scheme implements AttestationFile
+func (f mockFile) Scheme() string {
+	return f.scheme
+}
+
+// Contents implements AttestationFile
+func (f mockFile) Contents() ([]byte, error) {
+	return make([]byte, 0), nil
+}
+
+// Path implements AttestationFile
+func (f mockFile) Path() string {
+	return f.path
+}
+
+// Platform implements AttestationFile
+func (mockFile) Platform() *v1.Platform {
+	return nil
+}
+
+// String implements AttestationFile
+func (f mockFile) String() string {
+	return f.scheme + "://" + f.path
+}
+
+var _ cremote.File = mockFile{}
+
+func TestBuildOciRef(t *testing.T) {
+
+	testCases := []struct {
+		name           string
+		repo           string
+		version        string
+		tagPrefix      string
+		attType        string
+		expectedResult string
+		expectedErrMsg string
+	}{
+		{
+			name:           "with tag-prefix parameter",
+			repo:           "ghcr.io/philips-labs/fatt-attestations-example",
+			version:        "v0.1.0",
+			tagPrefix:      "test-application",
+			attType:        "sbom",
+			expectedResult: "ghcr.io/philips-labs/fatt-attestations-example:test-application-v0.1.0.sbom",
+		},
+		{
+			name:           "without tag-prefix parameter",
+			repo:           "ghcr.io/philips-labs/fatt-attestations-example",
+			version:        "v0.1.0",
+			tagPrefix:      "",
+			attType:        "sbom",
+			expectedResult: "ghcr.io/philips-labs/fatt-attestations-example:v0.1.0.sbom",
+		},
+		{
+			name:           "without version parameter",
+			repo:           "ghcr.io/philips-labs/fatt-attestations-example",
+			version:        "",
+			tagPrefix:      "test-application",
+			attType:        "sbom",
+			expectedErrMsg: "version is required",
+		},
+		{
+			name:           "without attestation type parameter",
+			repo:           "ghcr.io/philips-labs/fatt-attestations-example",
+			version:        "v1.0.0",
+			tagPrefix:      "test-application",
+			expectedErrMsg: "attestation type is required",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			assert := assert.New(tt)
+			results, err := buildOciRef(tc.repo, tc.tagPrefix, tc.version, tc.attType)
+			if tc.expectedErrMsg != "" {
+				assert.Error(err)
+				assert.EqualError(err, tc.expectedErrMsg)
+				assert.Nil(results)
+			} else {
+				assert.NoError(err)
+				assert.Equal(results.String(), tc.expectedResult)
+			}
+		})
+	}
+}
+func TestPublish(t *testing.T) {
+	sbom := mockFile{
+		scheme: "sbom://",
+		path:   "something.txt",
+	}
+	invalidFile := file{
+		scheme: "stuff://",
+		path:   "stuff-spdx.json",
+	}
+
+	testCases := []struct {
+		name           string
+		repo           string
+		version        string
+		tagPrefix      string
+		file           cremote.File
+		expectedErrMsg string
+	}{
+		{
+			name:           "empty args",
+			repo:           "",
+			version:        "",
+			tagPrefix:      "",
+			expectedErrMsg: "repository parameter is required",
+		},
+		{
+			name:           "without version but with tag-prefix parameter",
+			repo:           "ghcr.io/philips-labs/fatt-attestations-example",
+			version:        "",
+			tagPrefix:      "test-application",
+			file:           sbom,
+			expectedErrMsg: "version is required",
+		},
+		{
+			name:           "without file parameter",
+			repo:           "ghcr.io/philips-labs/fatt-attestations-example",
+			version:        "v0.1.0",
+			tagPrefix:      "test-application",
+			expectedErrMsg: "attestation file parameter is required",
+		},
+		{
+			name:           "with invalid file parameter",
+			repo:           "ghcr.io/philips-labs/fatt-attestations-example",
+			version:        "v0.1.0",
+			tagPrefix:      "test-application",
+			file:           invalidFile,
+			expectedErrMsg: "currently only sbom:// and provenance:// schemes are supported",
+		},
+	}
+	ctx := context.Background()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			assert := assert.New(tt)
+			results, err := Publish(ctx, tc.repo, tc.tagPrefix, tc.version, tc.file)
+			if tc.expectedErrMsg != "" {
+				assert.Error(err)
+				assert.EqualError(err, tc.expectedErrMsg)
+				assert.Nil(results)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #25 

Try it out with the following command: `bin/fatt publish --repository ghcr.io/philips-labs/fatt-attestations-example --version v0.1.0 --tag-prefix tester-app sbom://sbom-spdx.json provenance://provenance.att`
Result:
```
$  bin/fatt publish --repository ghcr.io/philips-labs/fatt-attestations-example --version v0.1.0 --tag-prefix tester-app sbom://sbom-spdx.json provenance://provenance.att
Publishing attestations…
Uploading file from [sbom-spdx.json] to [ghcr.io/philips-labs/fatt-attestations-example:tester-app-v0.1.0.sbom] with media type [text/plain]
File [sbom-spdx.json] is available directly at [ghcr.io/v2/philips-labs/fatt-attestations-example/blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855]
Uploading file from [provenance.att] to [ghcr.io/philips-labs/fatt-attestations-example:tester-app-v0.1.0.provenance] with media type [text/plain]
File [provenance.att] is available directly at [ghcr.io/v2/philips-labs/fatt-attestations-example/blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855]

Generating attestations.txt based on uploaded attestations…
Uploading file from [attestations.txt] to [ghcr.io/philips-labs/fatt-attestations-example:tester-app-v0.1.0.discovery] with media type [text/plain]
File [attestations.txt] is available directly at [ghcr.io/v2/philips-labs/fatt-attestations-example/blobs/sha256:07ef1877335c711e65e7a13d5c81ea122409ba15f0d3f15441d9e982c4c4bd20]
```

Signed-off-by: Brend Smits <brend.smits@philips.com>
